### PR TITLE
Fix NPE because of missing reference

### DIFF
--- a/nodes/store.js
+++ b/nodes/store.js
@@ -29,7 +29,7 @@ module.exports = RED => {
         this.debug(`Key-value store ready at ${filepath}`);
       })
       .catch(err => {
-        node.error(`Failed to load key-value store at ${filepath}:\n\n${err}`);
+        this.error(`Failed to load key-value store at ${filepath}:\n\n${err}`);
       });
   };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
  "name": "node-red-contrib-key-value-store",
- "version": "0.1.8",
+ "version": "0.1.9",
  "lockfileVersion": 1,
  "requires": true,
  "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,69 +1,184 @@
 {
- "name": "node-red-contrib-key-value-store",
- "version": "0.1.9",
- "lockfileVersion": 1,
- "requires": true,
- "dependencies": {
-  "graceful-fs": {
-   "version": "4.1.11",
-   "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-   "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
+  "name": "node-red-contrib-key-value-store",
+  "version": "0.1.9",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "node-red-contrib-key-value-store",
+      "version": "0.1.9",
+      "license": "MIT",
+      "dependencies": {
+        "is-relative": "^1.0.0",
+        "lowdb": "^1.0.0",
+        "node-red-contrib-key-value-store": "file:node-red-contrib-key-value-store-0.1.9.tgz"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
+      "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o="
+    },
+    "node_modules/is-relative": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-1.0.0.tgz",
+      "integrity": "sha512-Kw/ReK0iqwKeu0MITLFuj0jbPAmEiOsIwyIXvvbfa6QfmN9pkD1M+8pdk7Rl/dTKbH34/XBFMbgD4iMJhLQbGA==",
+      "dependencies": {
+        "is-unc-path": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-unc-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-unc-path/-/is-unc-path-1.0.0.tgz",
+      "integrity": "sha512-mrGpVd0fs7WWLfVsStvgF6iEJnbjDFZh9/emhRDcGWTduTfNHd9CHeUwH3gYIjdbwo4On6hunkztwOaAw0yllQ==",
+      "dependencies": {
+        "unc-path-regex": "^0.1.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/lodash": {
+      "version": "4.17.5",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
+      "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw=="
+    },
+    "node_modules/lowdb": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/lowdb/-/lowdb-1.0.0.tgz",
+      "integrity": "sha512-2+x8esE/Wb9SQ1F9IHaYWfsC9FIecLOPrK4g17FGEayjUWH172H6nwicRovGvSE2CPZouc2MCIqCI7h9d+GftQ==",
+      "dependencies": {
+        "graceful-fs": "^4.1.3",
+        "is-promise": "^2.1.0",
+        "lodash": "4",
+        "pify": "^3.0.0",
+        "steno": "^0.4.1"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/node-red-contrib-key-value-store": {
+      "version": "0.1.9",
+      "resolved": "file:node-red-contrib-key-value-store-0.1.9.tgz",
+      "integrity": "sha512-V7AqT6C+bzoTLZLla9xfV3nFmzrZ8gnFIWZE+5w4hlES3w3/1dk3LfmxgRx7lnURAGdwm3e/J0hmwlLOhv1/rQ==",
+      "license": "MIT",
+      "dependencies": {
+        "is-relative": "^1.0.0",
+        "lowdb": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/pify": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+      "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/steno": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/steno/-/steno-0.4.4.tgz",
+      "integrity": "sha1-BxEFvfwobmYVwEA8J+nXtdy4Vcs=",
+      "dependencies": {
+        "graceful-fs": "^4.1.3"
+      }
+    },
+    "node_modules/unc-path-regex": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/unc-path-regex/-/unc-path-regex-0.1.2.tgz",
+      "integrity": "sha1-5z3T17DXxe2G+6xrCufYxqadUPo=",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    }
   },
-  "is-promise": {
-   "version": "2.1.0",
-   "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
-   "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o="
-  },
-  "is-relative": {
-   "version": "1.0.0",
-   "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-1.0.0.tgz",
-   "integrity": "sha512-Kw/ReK0iqwKeu0MITLFuj0jbPAmEiOsIwyIXvvbfa6QfmN9pkD1M+8pdk7Rl/dTKbH34/XBFMbgD4iMJhLQbGA==",
-   "requires": {
-    "is-unc-path": "1.0.0"
-   }
-  },
-  "is-unc-path": {
-   "version": "1.0.0",
-   "resolved": "https://registry.npmjs.org/is-unc-path/-/is-unc-path-1.0.0.tgz",
-   "integrity": "sha512-mrGpVd0fs7WWLfVsStvgF6iEJnbjDFZh9/emhRDcGWTduTfNHd9CHeUwH3gYIjdbwo4On6hunkztwOaAw0yllQ==",
-   "requires": {
-    "unc-path-regex": "0.1.2"
-   }
-  },
-  "lodash": {
-   "version": "4.17.5",
-   "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
-   "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw=="
-  },
-  "lowdb": {
-   "version": "1.0.0",
-   "resolved": "https://registry.npmjs.org/lowdb/-/lowdb-1.0.0.tgz",
-   "integrity": "sha512-2+x8esE/Wb9SQ1F9IHaYWfsC9FIecLOPrK4g17FGEayjUWH172H6nwicRovGvSE2CPZouc2MCIqCI7h9d+GftQ==",
-   "requires": {
-    "graceful-fs": "4.1.11",
-    "is-promise": "2.1.0",
-    "lodash": "4.17.5",
-    "pify": "3.0.0",
-    "steno": "0.4.4"
-   }
-  },
-  "pify": {
-   "version": "3.0.0",
-   "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-   "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
-  },
-  "steno": {
-   "version": "0.4.4",
-   "resolved": "https://registry.npmjs.org/steno/-/steno-0.4.4.tgz",
-   "integrity": "sha1-BxEFvfwobmYVwEA8J+nXtdy4Vcs=",
-   "requires": {
-    "graceful-fs": "4.1.11"
-   }
-  },
-  "unc-path-regex": {
-   "version": "0.1.2",
-   "resolved": "https://registry.npmjs.org/unc-path-regex/-/unc-path-regex-0.1.2.tgz",
-   "integrity": "sha1-5z3T17DXxe2G+6xrCufYxqadUPo="
+  "dependencies": {
+    "graceful-fs": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
+    },
+    "is-promise": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
+      "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o="
+    },
+    "is-relative": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-1.0.0.tgz",
+      "integrity": "sha512-Kw/ReK0iqwKeu0MITLFuj0jbPAmEiOsIwyIXvvbfa6QfmN9pkD1M+8pdk7Rl/dTKbH34/XBFMbgD4iMJhLQbGA==",
+      "requires": {
+        "is-unc-path": "^1.0.0"
+      }
+    },
+    "is-unc-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-unc-path/-/is-unc-path-1.0.0.tgz",
+      "integrity": "sha512-mrGpVd0fs7WWLfVsStvgF6iEJnbjDFZh9/emhRDcGWTduTfNHd9CHeUwH3gYIjdbwo4On6hunkztwOaAw0yllQ==",
+      "requires": {
+        "unc-path-regex": "^0.1.2"
+      }
+    },
+    "lodash": {
+      "version": "4.17.5",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
+      "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw=="
+    },
+    "lowdb": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/lowdb/-/lowdb-1.0.0.tgz",
+      "integrity": "sha512-2+x8esE/Wb9SQ1F9IHaYWfsC9FIecLOPrK4g17FGEayjUWH172H6nwicRovGvSE2CPZouc2MCIqCI7h9d+GftQ==",
+      "requires": {
+        "graceful-fs": "^4.1.3",
+        "is-promise": "^2.1.0",
+        "lodash": "4",
+        "pify": "^3.0.0",
+        "steno": "^0.4.1"
+      }
+    },
+    "node-red-contrib-key-value-store": {
+      "version": "file:node-red-contrib-key-value-store-0.1.9.tgz",
+      "integrity": "sha512-V7AqT6C+bzoTLZLla9xfV3nFmzrZ8gnFIWZE+5w4hlES3w3/1dk3LfmxgRx7lnURAGdwm3e/J0hmwlLOhv1/rQ==",
+      "requires": {
+        "is-relative": "^1.0.0",
+        "lowdb": "^1.0.0"
+      }
+    },
+    "pify": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+      "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
+    },
+    "steno": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/steno/-/steno-0.4.4.tgz",
+      "integrity": "sha1-BxEFvfwobmYVwEA8J+nXtdy4Vcs=",
+      "requires": {
+        "graceful-fs": "^4.1.3"
+      }
+    },
+    "unc-path-regex": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/unc-path-regex/-/unc-path-regex-0.1.2.tgz",
+      "integrity": "sha1-5z3T17DXxe2G+6xrCufYxqadUPo="
+    }
   }
- }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-red-contrib-key-value-store",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "Simple, persistent, JSON-based key-value store for Node-RED",
   "author": "Christopher Hiller <boneskull@boneskull.com>",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "author": "Christopher Hiller <boneskull@boneskull.com>",
   "dependencies": {
     "is-relative": "^1.0.0",
-    "lowdb": "^1.0.0"
+    "lowdb": "^1.0.0",
+    "node-red-contrib-key-value-store": "file:node-red-contrib-key-value-store-0.1.9.tgz"
   },
   "license": "MIT",
   "keywords": [


### PR DESCRIPTION
If the file path does not exist, the start-up of the module fails with an unhandled exception due to the non-existing reference to the **node** object, while trying to log the error message.
